### PR TITLE
chore: update solver to v1.3.0 with oauth secret and mongo db

### DIFF
--- a/charts/planufacture/templates/deployment.yaml
+++ b/charts/planufacture/templates/deployment.yaml
@@ -91,6 +91,18 @@ spec:
                   name: {{ include "planufacture.fullname" $ }}-diomac
                   key: key
             {{- end }}
+            {{- if eq $key "solver" }}
+            - name: SOLVER_OAUTH2_CLIENT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "planufacture.fullname" $ }}-solver
+                  key: clientId
+            - name: SOLVER_OAUTH2_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "planufacture.fullname" $ }}-solver
+                  key: clientSecret
+            {{- end }}
             {{- if .redis }}
             - name: SPRING_DATA_REDIS_HOST
               value: "{{ $.Release.Name }}-redis-master"

--- a/charts/planufacture/templates/secret-solver.yaml
+++ b/charts/planufacture/templates/secret-solver.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "planufacture.fullname" $ }}-solver
+  labels:
+    {{- include "planufacture.labels" . | nindent 4 }}
+data:
+  clientId: {{ required "A valid .Values.solver.clientId is required" .Values.solver.clientId | b64enc | quote }}
+  clientSecret: {{ required "A valid .Values.solver.clientSecret is required" .Values.solver.clientSecret | b64enc | quote }}
+

--- a/charts/planufacture/values.yaml
+++ b/charts/planufacture/values.yaml
@@ -78,6 +78,9 @@ microServices:
       db: diomac-connector
       # existingSecret: atlas-diomac-connector-credentials
       # existingSecretKey: mongo-uri
+  solver:
+    image:
+      tag: 1.3.0
 busybox:
   image:
     repository: 503561419401.dkr.ecr.eu-west-1.amazonaws.com/docker-hub/library/busybox

--- a/charts/planufacture/values.yaml
+++ b/charts/planufacture/values.yaml
@@ -83,6 +83,10 @@ microServices:
     image:
       repository: ghcr.io/planufacture/solver
       tag: 1.3.0
+    mongo:
+      db: solver
+      # existingSecret: atlas-solver-credentials
+      # existingSecretKey: mongo-uri
     service:
       port: 9520
     startupProbe:
@@ -251,6 +255,7 @@ volumeMounts: []
 #   readOnly: true
 
 diomac: {}
+solver: {}
 metrics:
   enabled: false
   serviceMonitor:

--- a/charts/planufacture/values.yaml
+++ b/charts/planufacture/values.yaml
@@ -52,6 +52,7 @@ microServices:
       limits:
         cpu: '1'
         memory: 1Gi
+
   gateway:
     replicaCount: 2
     redis: true
@@ -80,7 +81,24 @@ microServices:
       # existingSecretKey: mongo-uri
   solver:
     image:
+      repository: ghcr.io/planufacture/solver
       tag: 1.3.0
+    service:
+      port: 9520
+    startupProbe:
+      httpGet:
+        path: /
+        port: http
+      failureThreshold: 10
+      periodSeconds: 5
+    livenessProbe:
+      httpGet:
+        path: /
+        port: http
+    readinessProbe:
+      httpGet:
+        path: /
+        port: http
 busybox:
   image:
     repository: 503561419401.dkr.ecr.eu-west-1.amazonaws.com/docker-hub/library/busybox


### PR DESCRIPTION
## Summary
- Bumps the solver service to `v1.3.0` and adds matching configuration in `values.yaml`
- Adds a new `-solver` Secret (`clientId` / `clientSecret`) sourced from top-level `.Values.solver.*`, mirroring the existing `diomac` pattern
- Wires `SOLVER_OAUTH2_CLIENT` / `SOLVER_OAUTH2_SECRET` into the solver Deployment via a `$key == "solver"` clause in `deployment.yaml`
- Provisions a `solver` MongoDB database for the service (uses the chart's mongo, or `existingSecret` when `mongo.enabled: false`)

## Test plan
- [ ] `ct lint --config ct.yaml` passes
- [ ] `helm template` renders cleanly with `solver.clientId` / `solver.clientSecret` supplied
- [ ] `helm template` fails fast with a clear error when `solver.clientId` / `solver.clientSecret` are missing
- [ ] On a dev install: solver pod starts, env vars `SOLVER_OAUTH2_CLIENT` / `SOLVER_OAUTH2_SECRET` are populated from the `-solver` secret
- [ ] `solver` MongoDB user is created by the post-install job and the solver service connects successfully