### PR TITLE
chore: remove solver probe overrides

### DIFF
--- a/charts/planufacture/values.yaml
+++ b/charts/planufacture/values.yaml
@@ -88,20 +88,6 @@ microServices:
       # existingSecretKey: mongo-uri
     service:
       port: 9520
-    startupProbe:
-      httpGet:
-        path: /
-        port: http
-      failureThreshold: 10
-      periodSeconds: 5
-    livenessProbe:
-      httpGet:
-        path: /
-        port: http
-    readinessProbe:
-      httpGet:
-        path: /
-        port: http
 busybox:
   image:
     repository: 503561419401.dkr.ecr.eu-west-1.amazonaws.com/docker-hub/library/busybox


### PR DESCRIPTION
## Summary
- Drop the `startupProbe` / `livenessProbe` / `readinessProbe` overrides on `microServices.solver` in `values.yaml`.
- Solver now inherits the chart-wide defaults defined later in the same file, which use the actuator endpoints (`/actuator/health`, `/actuator/health/liveness`, `/actuator/health/readiness`).
- Those paths match what `EndpointRequest.to("health")` permits in solver's `SecurityConfig`, so probes will succeed without an auth bypass on `/`.

## Test plan
- [ ] `helm template my-release charts/planufacture/ -f values/values-dev.yaml` and confirm the solver Deployment renders the actuator-based probes.
- [ ] Deploy to dev and confirm solver pod reaches Ready with no probe failures in events.