### PR TITLE
chore: drop bundled Bitnami redis, wire to shared cluster redis

### DIFF
--- a/charts/planufacture/Chart.lock
+++ b/charts/planufacture/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 23.2.12
-digest: sha256:c8775d69efb7e01fe7a15ac3fea364a44e2a9717bc6d29507c08bc2e6d0c9872
-generated: "2026-02-28T11:25:58.890317Z"

--- a/charts/planufacture/Chart.yaml
+++ b/charts/planufacture/Chart.yaml
@@ -26,9 +26,3 @@ version: 0.1.764
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.0.258"
-
-dependencies:
-  - name: redis
-    version: 23.x.x
-    repository: https://charts.bitnami.com/bitnami
-    condition: redis.enabled

--- a/charts/planufacture/templates/deployment.yaml
+++ b/charts/planufacture/templates/deployment.yaml
@@ -120,6 +120,11 @@ spec:
                 secretKeyRef:
                   name: {{ $.Values.redis.existingSecret }}
                   key: {{ $.Values.redis.existingSecretPasswordKey }}
+            # Spring Session Redis keys default to "spring:session:*". The
+            # tenant ACL user on the shared redis only permits "<namespace>:*",
+            # so prefix the session namespace with the release namespace.
+            - name: SPRING_SESSION_REDIS_NAMESPACE
+              value: "{{ $.Release.Namespace }}:spring:session"
             {{- end }}
             {{- with .env }}
             {{- toYaml . | nindent 12 }}

--- a/charts/planufacture/templates/deployment.yaml
+++ b/charts/planufacture/templates/deployment.yaml
@@ -105,14 +105,21 @@ spec:
             {{- end }}
             {{- if .redis }}
             - name: SPRING_DATA_REDIS_HOST
-              value: "{{ $.Release.Name }}-redis-master"
+              value: {{ required "redis.host is required when a microService has .redis: true" $.Values.redis.host | quote }}
             - name: SPRING_DATA_REDIS_PORT
-              value: "6379"
+              value: {{ $.Values.redis.port | quote }}
+            - name: SPRING_DATA_REDIS_SSL_ENABLED
+              value: {{ $.Values.redis.tls | quote }}
+            - name: SPRING_DATA_REDIS_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "redis.existingSecret is required when a microService has .redis: true" $.Values.redis.existingSecret }}
+                  key: {{ $.Values.redis.existingSecretUsernameKey }}
             - name: SPRING_DATA_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ $.Release.Name }}-redis"
-                  key: redis-password
+                  name: {{ $.Values.redis.existingSecret }}
+                  key: {{ $.Values.redis.existingSecretPasswordKey }}
             {{- end }}
             {{- with .env }}
             {{- toYaml . | nindent 12 }}

--- a/charts/planufacture/values.yaml
+++ b/charts/planufacture/values.yaml
@@ -123,27 +123,18 @@ axonserver:
     requests:
       cpu: 200m
       memory: 1Gi
+# Shared in-cluster Redis (Bitnami chart deployed by terraform/modules/redis-incluster
+# into the `infrastructure` namespace). Connection details come from a kubernetes
+# Secret (default name "redis-credentials") provisioned by the same module into
+# each tenant namespace. Apps must namespace keys with "<release-namespace>:" —
+# the ACL user only permits keys matching that prefix.
 redis:
-  enabled: true
-  global:
-    security:
-      allowInsecureImages: true
-  image:
-    registry: 503561419401.dkr.ecr.eu-west-1.amazonaws.com
-    repository: docker-hub/bitnami/redis
-    tag: latest
-  auth:
-    enabled: true
-  master:
-    persistence:
-      size: 1Gi
-    resources:
-      requests:
-        cpu: 200m
-        memory: 256Mi
-      limits:
-        cpu: '1'
-        memory: 1Gi
+  host: redis-master.infrastructure.svc
+  port: 6379
+  tls: false
+  existingSecret: redis-credentials
+  existingSecretUsernameKey: username
+  existingSecretPasswordKey: password
 rabbit: {}
 replicaCount: 1
 image:


### PR DESCRIPTION
## Summary

Stop shipping per-release Bitnami redis as a subchart dependency. Apps now point at the shared in-cluster redis deployed by `terraform/modules/redis-incluster` (single Bitnami release in the `infrastructure` namespace), reading credentials from the per-namespace `redis-credentials` Secret that the same Terraform module provisions.

## Changes

- **Chart.yaml**: drop the `dependencies` block (`bitnami/redis ~> 23.x`).
- **Chart.lock**: delete — no deps to lock anymore.
- **values.yaml**: replace bundled-redis config (`enabled`, `auth`, `master.persistence`, ECR image override, etc.) with shared-redis pointers — `host`, `port`, `tls`, `existingSecret`, `existingSecretUsernameKey`, `existingSecretPasswordKey`.
- **templates/deployment.yaml**: rewire `SPRING_DATA_REDIS_*` env vars. `HOST`/`PORT`/`SSL_ENABLED` come from values; `USERNAME`/`PASSWORD` come from the `redis-credentials` Secret (defaults `username` / `password` keys).

## Why now

PR #88 in `planufacture/terraform` provisions per-tenant ACL users on the shared redis and writes `redis-credentials` into each deployment namespace. With that in place we can retire the per-release embedded redis instances — saving compute, simplifying the per-tenant footprint, and lining up with the same pattern as RabbitMQ.

## Renders correctly

`helm template` against namespace `dearboy` produces:

```yaml
- name: SPRING_DATA_REDIS_HOST
  value: "redis-master.infrastructure.svc"
- name: SPRING_DATA_REDIS_PORT
  value: "6379"
- name: SPRING_DATA_REDIS_SSL_ENABLED
  value: "false"
- name: SPRING_DATA_REDIS_USERNAME
  valueFrom:
    secretKeyRef:
      name: redis-credentials
      key: username
- name: SPRING_DATA_REDIS_PASSWORD
  valueFrom:
    secretKeyRef:
      name: redis-credentials
      key: password
```

## Test plan

- [x] CI lint + render passes
- [ ] After release on a dev tenant: `kubectl exec` into a redis-using pod (e.g. gateway), confirm `$SPRING_DATA_REDIS_*` populated
- [ ] App connects with the tenant ACL user (only `<namespace>:*` keys permitted)
- [ ] Old per-release `<release>-redis-master` Service/StatefulSet can be GC'd separately (chart will no longer manage them after upgrade)

## Things to flag

- **Existing per-release redis instances**: this PR doesn't delete them. After all releases upgrade, the orphaned `<release>-redis-master` StatefulSets / Services / PVCs need to be reaped manually (or via a follow-up cleanup). They'll just sit unused.
- **Key prefixing**: the tenant ACL users only allow `<namespace>:*` keys. Apps that don't already prefix keys with the namespace will fail authz against the shared redis. Worth confirming on first rollout.