### PR TITLE
chore: source all redis connection details from redis-credentials secret

### DIFF
--- a/charts/planufacture/templates/deployment.yaml
+++ b/charts/planufacture/templates/deployment.yaml
@@ -105,21 +105,27 @@ spec:
             {{- end }}
             {{- if .redis }}
             - name: SPRING_DATA_REDIS_HOST
-              value: {{ required "redis.host is required when a microService has .redis: true" $.Values.redis.host | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "redis.existingSecret is required when a microService has .redis: true" $.Values.redis.existingSecret }}
+                  key: host
             - name: SPRING_DATA_REDIS_PORT
-              value: {{ $.Values.redis.port | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.redis.existingSecret }}
+                  key: port
             - name: SPRING_DATA_REDIS_SSL_ENABLED
               value: {{ $.Values.redis.tls | quote }}
             - name: SPRING_DATA_REDIS_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "redis.existingSecret is required when a microService has .redis: true" $.Values.redis.existingSecret }}
-                  key: {{ $.Values.redis.existingSecretUsernameKey }}
+                  name: {{ $.Values.redis.existingSecret }}
+                  key: username
             - name: SPRING_DATA_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ $.Values.redis.existingSecret }}
-                  key: {{ $.Values.redis.existingSecretPasswordKey }}
+                  key: password
             # Spring Session Redis keys default to "spring:session:*". The
             # tenant ACL user on the shared redis only permits "<namespace>:*",
             # so prefix the session namespace with the release namespace.

--- a/charts/planufacture/values.yaml
+++ b/charts/planufacture/values.yaml
@@ -124,17 +124,14 @@ axonserver:
       cpu: 200m
       memory: 1Gi
 # Shared in-cluster Redis (Bitnami chart deployed by terraform/modules/redis-incluster
-# into the `infrastructure` namespace). Connection details come from a kubernetes
-# Secret (default name "redis-credentials") provisioned by the same module into
-# each tenant namespace. Apps must namespace keys with "<release-namespace>:" —
-# the ACL user only permits keys matching that prefix.
+# into the `infrastructure` namespace). All connection details — host, port,
+# username, password — come from a kubernetes Secret (default name
+# "redis-credentials") provisioned by the same module into each tenant
+# namespace. Apps must namespace keys with "<release-namespace>:" — the ACL
+# user only permits keys matching that prefix.
 redis:
-  host: redis-master.infrastructure.svc
-  port: 6379
   tls: false
   existingSecret: redis-credentials
-  existingSecretUsernameKey: username
-  existingSecretPasswordKey: password
 rabbit: {}
 replicaCount: 1
 image:


### PR DESCRIPTION
## Summary

The chart hardcoded `redis.host: redis-master.infrastructure.svc` after PR #822, which broke when the upstream redis moved to replication+sentinel — under sentinel the master service is named `<release>` (not `<release>-master`), so DNS resolution fails:

> Caused by: java.net.UnknownHostException: Failed to resolve 'redis-master.infrastructure.svc'

The terraform `redis-incluster` module already writes the correct (sentinel-aware) host into the `redis-credentials` Secret's `host` key, alongside `port`, `username`, and `password`. Source all four from the Secret so the chart stays correct across architecture changes (standalone, replication, replication+sentinel) without needing a values update.

## Changes

- **values.yaml**: drop `redis.host`, `redis.port`, `redis.existingSecretUsernameKey`, `redis.existingSecretPasswordKey`. Keep `redis.tls` (plain bool — module always provisions plain redis on the pod network) and `redis.existingSecret` (defaults to `redis-credentials`).
- **deployment.yaml**: `SPRING_DATA_REDIS_HOST` and `_PORT` now come from `secretKeyRef` (keys `host`, `port`). `_USERNAME` / `_PASSWORD` continue to come from the Secret with hardcoded keys (`username`, `password`).

The Secret key names are stable across the redis-incluster module's lifetime, so they're hardcoded in the template rather than exposed as values.

## Renders correctly

```yaml
- name: SPRING_DATA_REDIS_HOST
  valueFrom:
    secretKeyRef:
      name: redis-credentials
      key: host
- name: SPRING_DATA_REDIS_PORT
  valueFrom:
    secretKeyRef:
      name: redis-credentials
      key: port
- name: SPRING_DATA_REDIS_SSL_ENABLED
  value: "false"
- name: SPRING_DATA_REDIS_USERNAME
  valueFrom:
    secretKeyRef:
      name: redis-credentials
      key: username
- name: SPRING_DATA_REDIS_PASSWORD
  valueFrom:
    secretKeyRef:
      name: redis-credentials
      key: password
- name: SPRING_SESSION_REDIS_NAMESPACE
  value: "dearboy:spring:session"
```

## Test plan

- [ ] CI lint + render passes
- [ ] On a dev tenant: `kubectl exec` into the gateway pod, confirm `$SPRING_DATA_REDIS_HOST` matches the current redis service in `infrastructure`
- [ ] App connects without `UnknownHostException` and Spring Session activity lands under `<namespace>:spring:session:*` keys

## Things to flag

In sentinel mode the Bitnami `<release>` service routes to all redis pods, not specifically the master. If writes start failing with `READONLY` after the host change resolves, we'll need to expose `sentinel-master` + `sentinel-nodes` keys on the Secret and switch Spring to sentinel-aware config (`spring.data.redis.sentinel.master` / `.nodes`). Not in scope for this PR.