### PR TITLE
feat: switch redis client to sentinel discovery

### DIFF
--- a/charts/planufacture/templates/deployment.yaml
+++ b/charts/planufacture/templates/deployment.yaml
@@ -104,16 +104,21 @@ spec:
                   key: clientSecret
             {{- end }}
             {{- if .redis }}
-            - name: SPRING_DATA_REDIS_HOST
+            # Sentinel discovery: Lettuce connects to a sentinel on port
+            # 26379 to find the current master, then talks to the master
+            # directly. The shared redis service round-robins across all
+            # pods, so a plain host/port connection lands writes on a
+            # replica and fails with READONLY.
+            - name: SPRING_DATA_REDIS_SENTINEL_MASTER
               valueFrom:
                 secretKeyRef:
                   name: {{ required "redis.existingSecret is required when a microService has .redis: true" $.Values.redis.existingSecret }}
-                  key: host
-            - name: SPRING_DATA_REDIS_PORT
+                  key: sentinel-master
+            - name: SPRING_DATA_REDIS_SENTINEL_NODES
               valueFrom:
                 secretKeyRef:
                   name: {{ $.Values.redis.existingSecret }}
-                  key: port
+                  key: sentinel-nodes
             - name: SPRING_DATA_REDIS_SSL_ENABLED
               value: {{ $.Values.redis.tls | quote }}
             - name: SPRING_DATA_REDIS_USERNAME


### PR DESCRIPTION
## Summary

After PR #823 wired apps at the shared cluster redis, writes fail with:

> io.lettuce.core.RedisReadOnlyException: READONLY You can't write against a read only replica.

Bitnami's \`redis\` service in sentinel mode round-robins across all redis pods, not just the master. The fix is sentinel discovery: Lettuce connects to a sentinel on port 26379, asks for the current master, and uses that for reads/writes. As a bonus, Lettuce subscribes to sentinel pub/sub and handles \`+switch-master\` events automatically — master pod failure recovers in ~60-90s with no manual intervention.

## Change

Replace direct host/port env vars with sentinel discovery vars on services that have \`.redis: true\`:

\`\`\`diff
- SPRING_DATA_REDIS_HOST  ← redis-credentials.host
- SPRING_DATA_REDIS_PORT  ← redis-credentials.port
+ SPRING_DATA_REDIS_SENTINEL_MASTER  ← redis-credentials.sentinel-master
+ SPRING_DATA_REDIS_SENTINEL_NODES   ← redis-credentials.sentinel-nodes
  SPRING_DATA_REDIS_SSL_ENABLED      (unchanged)
  SPRING_DATA_REDIS_USERNAME         (unchanged)
  SPRING_DATA_REDIS_PASSWORD         (unchanged)
  SPRING_SESSION_REDIS_NAMESPACE     (unchanged)
\`\`\`

## Depends on

[Terraform PR #91](https://github.com/planufacture/terraform/pull/91) — adds \`sentinel-master\` and \`sentinel-nodes\` keys to the \`redis-credentials\` Secret. **Do not merge until that has been applied** on \`development\`, otherwise the gateway will look up keys that don't exist yet and pods will stall in \`CreateContainerConfigError\`.

## Test plan

- [ ] Terraform PR #91 applied on \`development\` (verify with \`kubectl get secret redis-credentials -n development -o jsonpath='{.data.sentinel-master}' | base64 -d\` returns \`mymaster\`)
- [ ] CI lint + render passes
- [ ] After release: gateway pod env shows \`SPRING_DATA_REDIS_SENTINEL_*\`, no \`SPRING_DATA_REDIS_HOST/PORT\`
- [ ] App connects without \`READONLY\` errors
- [ ] (Optional resilience check) \`kubectl delete pod redis-node-0 -n infrastructure\`; gateway recovers in ~60-90s

## Things to flag

- Reads still go to the master by default. To distribute reads across replicas would need a \`LettuceClientConfigurationBuilderCustomizer\` setting \`ReadFrom.REPLICA_PREFERRED\` — not in scope.
- Failure detection takes ~60s (Bitnami's \`down-after-milliseconds\` default). To tune lower we'd parameterize that in the redis-incluster module.