### PR TITLE
feat: default chart to shared mongodb-credentials and rabbitmq-credentials secrets

### DIFF
--- a/charts/planufacture/templates/cronjob-diomac-connector.yaml
+++ b/charts/planufacture/templates/cronjob-diomac-connector.yaml
@@ -76,6 +76,33 @@ spec:
                     secretKeyRef:
                       name: {{ $.Values.keycloak.existingSecret }}
                       key: diomac-client-secret
+                {{- if $.Values.rabbit.existingSecret }}
+                - name: SPRING_RABBITMQ_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $.Values.rabbit.existingSecret }}
+                      key: host
+                - name: SPRING_RABBITMQ_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $.Values.rabbit.existingSecret }}
+                      key: port
+                - name: SPRING_RABBITMQ_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $.Values.rabbit.existingSecret }}
+                      key: username
+                - name: SPRING_RABBITMQ_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $.Values.rabbit.existingSecret }}
+                      key: password
+                - name: SPRING_RABBITMQ_VIRTUAL_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $.Values.rabbit.existingSecret }}
+                      key: vhost
+                {{- else }}
                 - name: SPRING_RABBITMQ_HOST
                   value: "rabbitmq-cluster.infrastructure.svc"
                 - name: SPRING_RABBITMQ_PORT
@@ -89,6 +116,7 @@ spec:
                       key: password
                 - name: SPRING_RABBITMQ_VIRTUAL_HOST
                   value: {{ $.Release.Namespace }}
+                {{- end }}
                 {{- with .env }}
                 {{- toYaml . | nindent 16 }}
                 {{- end }}

--- a/charts/planufacture/templates/deployment.yaml
+++ b/charts/planufacture/templates/deployment.yaml
@@ -72,6 +72,33 @@ spec:
                   {{- end }}
             {{- end }}
             {{- if .rabbit }}
+            {{- if $.Values.rabbit.existingSecret }}
+            - name: SPRING_RABBITMQ_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.rabbit.existingSecret }}
+                  key: host
+            - name: SPRING_RABBITMQ_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.rabbit.existingSecret }}
+                  key: port
+            - name: SPRING_RABBITMQ_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.rabbit.existingSecret }}
+                  key: username
+            - name: SPRING_RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.rabbit.existingSecret }}
+                  key: password
+            - name: SPRING_RABBITMQ_VIRTUAL_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.rabbit.existingSecret }}
+                  key: vhost
+            {{- else }}
             - name: SPRING_RABBITMQ_HOST
               value: "rabbitmq-cluster.infrastructure.svc"
             - name: SPRING_RABBITMQ_PORT
@@ -85,6 +112,7 @@ spec:
                   key: password
             - name: SPRING_RABBITMQ_VIRTUAL_HOST
               value: {{ $.Release.Namespace }}
+            {{- end }}
             - name: ADMIN_DIOMAC_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/planufacture/templates/deployment.yaml
+++ b/charts/planufacture/templates/deployment.yaml
@@ -113,6 +113,8 @@ spec:
             - name: SPRING_RABBITMQ_VIRTUAL_HOST
               value: {{ $.Release.Namespace }}
             {{- end }}
+            {{- end }}
+            {{- if eq $key "domain" }}
             - name: ADMIN_DIOMAC_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/planufacture/templates/secret-rabbit.yaml
+++ b/charts/planufacture/templates/secret-rabbit.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.rabbit.existingSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -7,3 +8,4 @@ metadata:
     {{- include "planufacture.labels" . | nindent 4 }}
 data:
   password: {{ required "A valid .Values.rabbit.password is required" .Values.rabbit.password | b64enc | quote }}
+{{- end }}

--- a/charts/planufacture/values.yaml
+++ b/charts/planufacture/values.yaml
@@ -36,8 +36,8 @@ microServices:
     replicaCount: 1
     mongo:
       db: domain
-      # existingSecret: atlas-domain-credentials
-      # existingSecretKey: mongo-uri
+      existingSecret: mongodb-credentials
+      existingSecretKey: domain-connection-string
     rabbit: true
     image:
       tag: 0.0.483
@@ -76,8 +76,8 @@ microServices:
       tag: 0.0.117
     mongo:
       db: diomac-connector
-      # existingSecret: atlas-diomac-connector-credentials
-      # existingSecretKey: mongo-uri
+      existingSecret: mongodb-credentials
+      existingSecretKey: diomac-connection-string
   solver:
     image:
       repository: ghcr.io/planufacture/solver
@@ -138,7 +138,14 @@ redis:
 # from this Secret.
 keycloak:
   existingSecret: keycloak-credentials
-rabbit: {}
+# Per-env credentials for the shared in-cluster RabbitMQ broker
+# (`rabbit.infrastructure.svc`), provisioned by terraform into a Secret in
+# each tenant namespace. Holds host, port, vhost, username, password, and a
+# full connection-string. When `existingSecret` is set, all SPRING_RABBITMQ_*
+# env vars are sourced from it; the old broker (rabbitmq-cluster) is used
+# when an env overrides this to an empty string and provides `rabbit.password`.
+rabbit:
+  existingSecret: rabbitmq-credentials
 replicaCount: 1
 image:
   repository: nginx


### PR DESCRIPTION
## Summary

Wires the chart defaults to the per-namespace Secrets terraform now provisions in each tenant:

- **`mongodb-credentials`** — Atlas connection strings, with per-service keys `<svc>-connection-string` for `domain` and `diomacConnector`.
- **`rabbitmq-credentials`** — credentials for the new in-cluster RabbitMQ broker (`rabbit.infrastructure.svc`), one user+vhost per env.

After this PR, new envs (e.g. `blanco-nino`) work out of the box with no `microServices.<svc>.mongo` or `rabbit` overrides. Existing envs keep working as long as their values files override these new defaults; migrating an env means deleting those overrides.

### Changes
- `values.yaml`: set Atlas mongo defaults on `domain` + `diomacConnector`; set `rabbit.existingSecret: rabbitmq-credentials`.
- `templates/deployment.yaml` + `templates/cronjob-diomac-connector.yaml`: branch `SPRING_RABBITMQ_*` env block on `$.Values.rabbit.existingSecret` (sourced from Secret when set; hardcoded old broker otherwise).
- `templates/secret-rabbit.yaml`: chart-managed `-rabbit` Secret now only renders when `rabbit.existingSecret` is unset.

`solver.mongo` is intentionally **not** defaulted — Atlas migration list is `[diomac, domain]` only. Envs running solver continue to override as today.

## ⚠️ Required updates to env values files before deploy

Existing env values files (gitignored / GitHub Secret) **must** be updated alongside this rollout, otherwise pods will fail on next deploy:

**Envs still on the old RabbitMQ broker** — add:
```yaml
rabbit:
  existingSecret: ""
  password: <existing>
```

**Envs still on existing per-service Atlas Secrets** — for each service, the old default key was `mongo-uri` (template fallback). The new default is `<svc>-connection-string`. Existing envs likely only override `existingSecret`, so add `existingSecretKey` explicitly:
```yaml
microServices:
  domain:
    mongo:
      existingSecret: <existing>
      existingSecretKey: mongo-uri   # or whatever key the existing Secret holds
  diomacConnector:
    mongo:
      existingSecret: <existing>
      existingSecretKey: mongo-uri
```
Verify the actual key in each env's Atlas Secret with `kubectl get secret -o yaml` before rolling out.

**`dearboy` (in-cluster mongo + old broker)** — must clear the new mongo defaults so the template falls through to the in-cluster branch:
```yaml
mongo:
  enabled: true
microServices:
  domain:
    mongo:
      existingSecret: ""
  diomacConnector:
    mongo:
      existingSecret: ""
rabbit:
  existingSecret: ""
  password: <existing>
```

## Test plan

Verified via `helm template` against three shapes:

- [x] **New-env defaults** (blanco-nino) → `mongodb-credentials` + `rabbitmq-credentials`, chart-managed `-rabbit` Secret absent
- [x] **Existing env on old broker + per-service Atlas Secret** → old Atlas Secret refs + hardcoded `rabbitmq-cluster.infrastructure.svc` + chart-managed `-rabbit` Secret present
- [x] **dearboy** (in-cluster mongo + old broker) → chart-created per-service Mongo Secret + old broker
- [x] `helm lint charts/planufacture/` clean

Post-merge:
- [ ] Smoke deploy to a non-prod tenant (blanco-nino) and confirm pods start, connect, and consume Rabbit messages
- [ ] Verify each existing env values file has the required overrides before its next deploy