### PR TITLE
feat: source gateway OIDC client id from keycloak-credentials secret

### DIFF
--- a/charts/planufacture/templates/deployment.yaml
+++ b/charts/planufacture/templates/deployment.yaml
@@ -135,6 +135,16 @@ spec:
                   name: {{ $.Values.keycloak.existingSecret }}
                   key: solver-client-secret
             {{- end }}
+            {{- if eq $key "gateway" }}
+            # Public OIDC client for the tenant's UI login flow — provisioned
+            # by terraform's keycloak-tenants module into the
+            # keycloak-credentials Secret. No client secret (Auth Code + PKCE).
+            - name: GATEWAY_OAUTH2_CLIENT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.keycloak.existingSecret }}
+                  key: gateway-client-id
+            {{- end }}
             {{- if .redis }}
             # Sentinel discovery: Lettuce connects to a sentinel on port
             # 26379 to find the current master, then talks to the master


### PR DESCRIPTION
## Summary

Inject `GATEWAY_OAUTH2_CLIENT` into the gateway deployment from the per-tenant `keycloak-credentials` Secret (key: `gateway-client-id`), matching the pattern already used for `solver` and `diomac-connector`.

Gateway uses a **public** OIDC client (Auth Code + PKCE) for the tenant UI login flow — no client secret needed, so only the client_id is injected.

```yaml
{{- if eq $key "gateway" }}
- name: GATEWAY_OAUTH2_CLIENT
  valueFrom:
    secretKeyRef:
      name: {{ $.Values.keycloak.existingSecret }}
      key: gateway-client-id
{{- end }}
```

## Open question (chart owner / app team)

The env var name follows the existing `SOLVER_OAUTH2_CLIENT` / `DIOMAC_OAUTH2_CLIENT` convention — i.e. the gateway app is assumed to read a custom property like `gateway.oauth2.client`. **If the gateway uses Spring's standard OAuth2 client auto-config** (`spring.security.oauth2.client.registration.<reg>.client-id: ${...}`), the env var should instead be `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_<REG>_CLIENT_ID`. Confirm against gateway's `application.yaml` placeholder before deploying.

Issuer URL is currently a constant baked into `application.yaml`; if it needs to become per-tenant later, terraform's `keycloak-tenants` module will need to add an issuer key to `keycloak-credentials` and the chart will need a second env var here.

## Test plan

- [x] `helm template` shows `GATEWAY_OAUTH2_CLIENT` injected only into the gateway deployment, pointing at `keycloak-credentials/gateway-client-id`
- [x] No other deployments affected
- [ ] After merge + deploy: confirm gateway pod env contains the expected value (`kubectl exec gateway-... -- env | grep GATEWAY_OAUTH2`) and the login flow works against Keycloak