### PR TITLE
chore: remove unused mongo wiring from solver

### DIFF
--- a/charts/planufacture/values.yaml
+++ b/charts/planufacture/values.yaml
@@ -82,10 +82,6 @@ microServices:
     image:
       repository: ghcr.io/planufacture/solver
       tag: 1.3.10
-    mongo:
-      db: solver
-      # existingSecret: atlas-solver-credentials
-      # existingSecretKey: mongo-uri
     service:
       port: 9520
 busybox:


### PR DESCRIPTION
## Summary

Solver doesn't connect to MongoDB, but `values.yaml` had a `mongo:` block under it. The block (a) triggered the chart's `microServices.solver.mongo.existingSecret is required when mongo.enabled is false` check unless every env values file pinned a fake secret, and (b) caused `job-mongo-accounts` to provision a solver DB user that nothing reads.

Removing the block makes solver render cleanly with no per-env override. Env values files that previously set `microServices.solver.mongo.existingSecret: atlas-solver-credentials` (e.g. blanco-nino) can drop that override.

## Test plan

- [x] `helm template` against blanco-nino values renders cleanly; solver Deployment has no `SPRING_DATA_MONGODB_URI` env var; domain + diomacConnector still wire mongo correctly from `mongodb-credentials`
- [x] `helm lint` clean
- [ ] After merge + deploy: confirm solver pod starts (it should — no mongo connection attempt)