### PR TITLE
feat: add mongo to solver service

### DIFF
--- a/charts/planufacture/values.yaml
+++ b/charts/planufacture/values.yaml
@@ -82,6 +82,10 @@ microServices:
     image:
       repository: ghcr.io/planufacture/solver
       tag: 1.3.22
+    mongo:
+      db: solver
+      existingSecret: mongodb-credentials
+      existingSecretKey: solver-connection-string
     service:
       port: 9520
 busybox:


### PR DESCRIPTION
## Summary
Wire MongoDB into the **solver** microservice by adding a `.mongo` block to `values.yaml`, matching the existing pattern used by `domain` and `diomacConnector`.

```yaml
  solver:
    ...
    mongo:
      db: solver
      existingSecret: mongodb-credentials
      existingSecretKey: solver-connection-string
```

This injects `SPRING_DATA_MONGODB_URI` into the solver Deployment, sourced from the `mongodb-credentials` secret under key `solver-connection-string`.

## Action needed before deploy
Since `mongo.enabled: false` (Atlas mode), the chart reads the URI from a **pre-existing** secret. The `mongodb-credentials` secret must have a new key `solver-connection-string` added in each environment — it is not created by the chart. (Follows the existing `<service>-connection-string` naming convention.)

## Verification
`helm template` renders the solver Deployment with the expected env var:
```
- name: SPRING_DATA_MONGODB_URI
  valueFrom:
    secretKeyRef:
      name: mongodb-credentials
      key: solver-connection-string
```

Chart version intentionally not bumped — handled by the release workflow on merge.