### PR TITLE
ci: use App token instead of GH_PAC for chart-update PRs

### DIFF
--- a/.github/workflows/update-helm-chart.yaml
+++ b/.github/workflows/update-helm-chart.yaml
@@ -11,9 +11,16 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v7.0.0
         with:
-          token: ${{ secrets.GH_PAC }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install yq
         run: |
@@ -39,7 +46,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GH_PAC }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore: update ${{ github.event.client_payload.service }} version to ${{ github.event.client_payload.version }}"
           title: "chore: update ${{ github.event.client_payload.service }} version to ${{ github.event.client_payload.version }}"
           body: |
@@ -52,7 +59,7 @@ jobs:
 # Enable when upgraded to GitHub teams
 #      - name: Auto-merge if checks pass
 #        env:
-#          GH_TOKEN: ${{ secrets.GH_PAC }}
+#          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 #        run: |
 #          PR_NUMBER=$(gh pr list --json number --jq '.[0].number')
 #          if [ ! -z "$PR_NUMBER" ]; then


### PR DESCRIPTION
Replaces the expiring `GH_PAC` PAT in `update-helm-chart.yaml` (the workflow that receives the `repository_dispatch` from each service and opens the chart-bump PR) with a short-lived `planufacture-release-bot` App installation token.

- checkout + `peter-evans/create-pull-request` now use the App token.
- The App token (like a PAT, unlike `GITHUB_TOKEN`) lets the auto-created PR trigger its checks — preserving the existing behaviour.
- Requires the App's **Pull requests: write** permission (now granted on the installation).

Last non-Maven consumer of `GH_PAC`; after this only `planufacture-parent` remains.