### PR TITLE
feat(chart): configurable imageRegistry for ECR pulls (drop the ghcr pull secret)

### DIFF
--- a/charts/planufacture/Chart.yaml
+++ b/charts/planufacture/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.1.911
+version: 0.1.912
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/planufacture/templates/cronjob-diomac-connector.yaml
+++ b/charts/planufacture/templates/cronjob-diomac-connector.yaml
@@ -28,7 +28,7 @@ spec:
           {{- end }}
           containers:
             - name: diomac-connector
-              image: "ghcr.io/planufacture/diomac-connector:{{ $.Values.microServices.diomacConnector.image.tag | default $.Chart.AppVersion }}"
+              image: "{{ $.Values.imageRegistry }}/planufacture/diomac-connector:{{ $.Values.microServices.diomacConnector.image.tag | default $.Chart.AppVersion }}"
               imagePullPolicy: {{ $.Values.image.pullPolicy }}
               securityContext:
                 allowPrivilegeEscalation: false

--- a/charts/planufacture/templates/deployment.yaml
+++ b/charts/planufacture/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: {{ $.Chart.Name }}-{{ $key | kebabcase }}
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
-          image: "{{ .image.repository | default (printf "ghcr.io/planufacture/planufacture-%s" ($key | kebabcase)) }}:{{ .image.tag | default $.Chart.AppVersion }}"
+          image: "{{ $.Values.imageRegistry }}/{{ .image.repository | default (printf "planufacture/planufacture-%s" ($key | kebabcase)) }}:{{ .image.tag | default $.Chart.AppVersion }}"
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/planufacture/values.yaml
+++ b/charts/planufacture/values.yaml
@@ -3,10 +3,15 @@
 # Declare variables to be passed into your templates.
 ---
 application: {}
+# Registry (host, optionally + pull-through-cache prefix) for the planufacture
+# service images. Defaults to ghcr.io. On EKS, override to the ECR mirror so
+# pods pull via node IAM and no imagePullSecret is needed, e.g.
+#   imageRegistry: 503561419401.dkr.ecr.eu-west-1.amazonaws.com/ghcr
+imageRegistry: ghcr.io
 microServices:
   ui:
     image:
-      repository: ghcr.io/planufacture/ui
+      repository: planufacture/ui
       tag: 0.1.47
     service:
       port: 3000
@@ -80,7 +85,7 @@ microServices:
       existingSecretKey: diomac-connection-string
   solver:
     image:
-      repository: ghcr.io/planufacture/solver
+      repository: planufacture/solver
       tag: 1.3.28
     mongo:
       db: solver
@@ -152,6 +157,9 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+# Only needed when pulling the planufacture images from ghcr.io (the default).
+# On EKS with imageRegistry pointed at the ECR mirror, pods pull via node IAM —
+# set this to [] and the ghcr pull secret is no longer required.
 imagePullSecrets:
   - name: planufacture-credentials
 nameOverride: ""


### PR DESCRIPTION
Lets EKS pull the planufacture service images from the **ECR pull-through cache mirror** instead of `ghcr.io`, so pods authenticate via the **node IAM role** and the manually-created `planufacture-credentials` (ghcr `GH_PAC`) imagePullSecret is **no longer required** — removing the last runtime `GH_PAC` dependency on EKS.

The node IAM already works for ECR (the docker-hub images — busybox/mongo/axonserver — already pull from `503561419401.dkr.ecr.eu-west-1.amazonaws.com/docker-hub/...` with no secret), so **no IAM change is needed**.

## Changes
- Add configurable **`imageRegistry`** (default `ghcr.io` → default rendering unchanged).
- Make service image paths registry-relative (`ui`, `solver`, and the `planufacture-<svc>` default); `cronjob-diomac-connector` too.
- Document `imagePullSecrets` (empty it on ECR).
- Chart `0.1.911 → 0.1.912`.

## Verified with `helm template`
- **Default:** byte-identical to today (`ghcr.io/planufacture/...`, pull secret present) — safe, no behaviour change until EKS opts in.
- **ECR override** (`imageRegistry: 503561419401.dkr.ecr.eu-west-1.amazonaws.com/ghcr`, `imagePullSecrets: []`): images render as `.../ghcr/planufacture/...` and **0** imagePullSecrets.

## To activate on EKS (in `HELM_VALUES`)
```yaml
imageRegistry: 503561419401.dkr.ecr.eu-west-1.amazonaws.com/ghcr   # confirm the ghcr cache prefix
imagePullSecrets: []
```
Then verify pods pull from ECR, and delete the `planufacture-credentials` secret.

## ⚠️ Two things to confirm before flipping EKS
1. **The ghcr pull-through-cache prefix** — docker-hub uses `docker-hub`; I assumed `ghcr` for the ghcr upstream. Confirm the actual prefix.
2. **The ghcr cache's upstream credential** — `ghcr.io/planufacture/*` images are **private**, so the ECR pull-through cache rule needs a stored ghcr credential (in Secrets Manager) to fetch them. That should be a **long-lived `read:packages` PAT** (not `GH_PAC`). This is where the one remaining ghcr credential lives — one place in AWS, not in every cluster.